### PR TITLE
💡ENH - Use scipy curve fit when fit method least-squares

### DIFF
--- a/src/pymdea/core.py
+++ b/src/pymdea/core.py
@@ -7,7 +7,13 @@ from typing import Literal, Self
 import numpy as np
 import polars as pl
 from scipy import stats
+from scipy.optimize import curve_fit
 from tqdm import tqdm
+
+
+def _power_log(x: float, a: float, b: float) -> float:
+    """Log power law for curve fit."""
+    return (a * np.log(x)) + b
 
 
 class DeaLoader:
@@ -153,7 +159,11 @@ class DeaEngine:
                 applied to log-scale data. Prefer the more robust 'theilsen' or
                 'siegel' methods.""",
             )
-            coefficients = np.polyfit(np.log(length_slice), s_slice, 1)
+            coefficients = curve_fit(
+                f=_power_log,
+                xdata=length_slice,
+                ydata=s_slice,
+            )[0]  # 0 is coeffs, 1 is uncertainty, uncertainty not yet used
         if self.fit_method == "theilsen":
             coefficients = stats.theilslopes(s_slice, np.log(length_slice))
         if self.fit_method == "siegel":


### PR DESCRIPTION
# Proposed changes

Numpy 1.4 introduced the `numpy.polynomial` module and using `numpy.polyfit` is now discouraged.

Difficulty: `numpy.polynomial`'s `Polynomial.fit()` method returns coefficients in the reverse order from `numpy.polyfit()`, which is confusing and would require further changes in the methods for `DeaPlotter`.

Solution: Use `scipy.optimize.curve_fit()` with the exact function, $\delta\ln(x)+C$.

Note: `scipy.optimize.curve_fit()` still used least-squares, so this fit method is still less robust than `"siegel"` or `"theilsen"`.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
