### PR TITLE
💡ENH - Use element-wise conditions to check stripe crossings

### DIFF
--- a/src/pymdea/core.py
+++ b/src/pymdea/core.py
@@ -147,8 +147,8 @@ class DeaEngine:
 
     def _get_events(self: Self) -> Self:
         """Record an event (1) when `series` changes value."""
-        no_lower_crossing = self.series[1:] < np.floor(self.series[:-1]) + 1
-        no_upper_crossing = self.series[1:] > np.ceil(self.series[:-1]) - 1
+        no_upper_crossing = self.series[1:] < np.floor(self.series[:-1]) + 1
+        no_lower_crossing = self.series[1:] > np.ceil(self.series[:-1]) - 1
         events = np.where(no_lower_crossing & no_upper_crossing, 0, 1)
         self.events = np.append([0], events)  # Event impossible at index 0
         return self

--- a/src/pymdea/core.py
+++ b/src/pymdea/core.py
@@ -140,9 +140,7 @@ class DeaEngine:
             self.data = self.data + np.abs(np.min(self.data))
         elif np.min(self.data) > 0:
             self.data = self.data - np.abs(np.min(self.data))
-        max_data = np.max(self.data)
-        min_data = np.min(self.data)
-        data_width = np.abs(max_data - min_data)
+        data_width = np.abs(self.data.max() - self.data.min())
         stripe_size = data_width / self.number_of_stripes
         self.series = self.data / stripe_size
         return self

--- a/src/pymdea/core.py
+++ b/src/pymdea/core.py
@@ -147,15 +147,10 @@ class DeaEngine:
 
     def _get_events(self: Self) -> Self:
         """Record an event (1) when `series` changes value."""
-        events = np.zeros(len(self.series))
-        for i in range(1, len(self.series)):
-            if not (
-                self.series[i] < np.floor(self.series[i - 1]) + 1
-                and self.series[i] > np.ceil(self.series[i - 1]) - 1
-            ):
-                events[i] = 1
-        np.append(events, 0)
-        self.events = events
+        no_lower_crossing = self.series[1:] < np.floor(self.series[:-1]) + 1
+        no_upper_crossing = self.series[1:] > np.ceil(self.series[:-1]) - 1
+        events = np.where(no_lower_crossing & no_upper_crossing, 0, 1)
+        self.events = np.append([0], events)  # Event impossible at index 0
         return self
 
     def _make_trajectory(self: Self) -> Self:


### PR DESCRIPTION
# Proposed changes

Changed `pymdea.core.DeaEngine._get_events()` to use `numpy.where()` instead of a `for` loop to check for stripe crossings.

Logic is unchanged, only now the conditions for stripe crossings are made variables and passed to `numpy.where()` to be checked element-wise rather than iteratively.