### PR TITLE
📝DOC - Fix docstring mistypes and add pip to index

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -9,7 +9,14 @@ For further details about the method and how it works, please see [Culbreth, G.,
 
 ## Installation and use
 
-You'll need an up to date Python installation, e.g., through [uv](https://docs.astral.sh/uv/#python-management). Once you have one, clone this repository to a location on your file system where you can work with the files.
+The pymdea package is available on pypi and can be installed with pip:
+```bash
+pip install pymdea
+```
+pymdea can also be installed with [uv](https://docs.astral.sh/uv/#python-management)
+```bash
+uv add pymdea
+```
 
 ## Built with
 

--- a/docs/user-guide/getting-started.ipynb
+++ b/docs/user-guide/getting-started.ipynb
@@ -22,6 +22,13 @@
     "\n",
     "### With uv\n",
     "\n",
+    "pymdea can also be installed from PyPI with [uv](https://docs.astral.sh/uv):\n",
+    "```\n",
+    "uv add pymdea\n",
+    "```\n",
+    "\n",
+    "### With uv from source\n",
+    "\n",
     "#### Install uv\n",
     "\n",
     "Install the [uv python project manager](https://docs.astral.sh/uv), following the instructions on uv's [official installation guide](https://docs.astral.sh/uv/getting-started/installation).\n",
@@ -87,7 +94,7 @@
    "outputs": [],
    "source": [
     "from pymdea.core import DeaEngine, DeaLoader\n",
-    "from pymdea.plot import DeaPlotter\n"
+    "from pymdea.plot import DeaPlotter"
    ]
   },
   {

--- a/src/pymdea/core.py
+++ b/src/pymdea/core.py
@@ -319,7 +319,7 @@ class DeaEngine:
         fit_stop: int,
         fit_method: Literal["siegel", "theilsen", "ls"] = "siegel",
     ) -> Self:
-        """Run a modified diffusion entropy analysis.
+        """Run a regular diffusion entropy analysis.
 
         Parameters
         ----------


### PR DESCRIPTION
# Proposed changes

### src/pymdea/core.py

- Fixed mistype in `analyze_without_stripes`

### docs/user-guide/getting-started.ipynb

- Add basic `uv add` installation option

### docs/index.md

- Add pip and uv install options from README.md
