### PR TITLE
🐞FIX! - Generating results plots in non-jupyter

### DIFF
--- a/src/pymdea/plot.py
+++ b/src/pymdea/plot.py
@@ -52,7 +52,7 @@ class DeaPlotter:
 
         """
         x_line = np.linspace(start=1, stop=np.max(self.window_lengths), num=3)
-        fig, ax = plt.subplots(figsize=(fig_width, fig_height))
+        fig, ax = plt.subplots(figsize=(fig_width, fig_height), layout="constrained")
         ax.plot(
             self.window_lengths,
             self.entropies,
@@ -92,7 +92,7 @@ class DeaPlotter:
         y2 = 1 / (x2 - 1)
         y3 = np.full(100, 0.5)
 
-        fig, ax = plt.subplots(figsize=(fig_width, fig_height))
+        fig, ax = plt.subplots(figsize=(fig_width, fig_height), layout="constrained")
         ax.plot(x1, y1, color="k")
         ax.plot(x2, y2, color="k")
         ax.plot(x3, y3, color="k")

--- a/src/pymdea/plot.py
+++ b/src/pymdea/plot.py
@@ -72,7 +72,7 @@ class DeaPlotter:
         ax.set_ylabel("$S(L)$")
         ax.legend(loc=0)
         sns.despine(trim=True)
-        plt.show(fig)
+        self.fig_s_vs_l = fig
 
     def mu_candidates(self: Self, fig_width: int = 4, fig_height: int = 3) -> None:
         """Plot the possible values of mu.
@@ -123,4 +123,4 @@ class DeaPlotter:
         ax.legend(loc=0)
         ax.grid(visible=True)
         sns.despine(left=True, bottom=True)
-        plt.show(fig)
+        self.fig_mu_candidates = fig

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -1,0 +1,44 @@
+"""Tests for the core methods."""
+
+from typing import Self
+
+import matplotlib.pyplot as plt
+
+from src.pymdea.core import DeaEngine, DeaLoader
+from src.pymdea.plot import DeaPlotter
+
+
+class TestPlotter:
+    """Tests for the DeaEngine."""
+
+    def test_s_vs_l(self: Self) -> None:
+        """Test the _calculate_mu method."""
+        dea_loader = DeaLoader()
+        dea_loader.make_sample_data(1000)
+        dea_engine = DeaEngine(dea_loader)
+        dea_engine.analyze_with_stripes(fit_start=0.1, fit_stop=0.9)
+        dea_plotter = DeaPlotter(dea_engine)
+        dea_plotter.s_vs_l()
+        assert hasattr(dea_plotter, "fig_s_vs_l"), "fig_s_vs_l is missing"
+        assert isinstance(
+            dea_plotter.fig_s_vs_l, plt.Figure,
+        ), "fig_s_vs_l is not a matplotlib figure."
+
+    def test_mu_candidates(self: Self) -> None:
+        """Test the _calculate_mu method."""
+        dea_loader = DeaLoader()
+        dea_loader.make_sample_data(1000)
+        dea_engine = DeaEngine(dea_loader)
+        dea_engine.analyze_with_stripes(fit_start=0.1, fit_stop=0.9)
+        dea_plotter = DeaPlotter(dea_engine)
+        dea_plotter.mu_candidates()
+        assert hasattr(dea_plotter, "fig_mu_candidates"), "fig_mu_candidates is missing"
+        assert isinstance(
+            dea_plotter.fig_mu_candidates, plt.Figure,
+        ), "fig_mu_candidates is not a matplotlib figure."
+
+
+if __name__ == "__main__":
+    test_plotter = TestPlotter()
+    test_plotter.test_s_vs_l()
+    test_plotter.test_mu_candidates()


### PR DESCRIPTION
# Proposed changes

Fixed an issue which caused figure plotting methods to fail when invoked outside of a Jupyter notebook. This involved changing the return types of the plotting methods to generate the matplotlib figures as object attributes. The `plt.show()` command now plays nice with them.

Added tests for the plot module.

## Types of changes


- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
