### PR TITLE
✨ENH - Plot with base matplotlib styles instead of requiring seaborn.set_theme

### DIFF
--- a/src/pymdea/plot.py
+++ b/src/pymdea/plot.py
@@ -1,6 +1,6 @@
 """Plotting functions."""
 
-from typing import Literal, Self
+from typing import Self
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -15,8 +15,7 @@ class DeaPlotter:
     def __init__(
         self: Self,
         model: DeaEngine,
-        theme: Literal["ticks", "whitegrid", "darkgrid"] = "ticks",
-        colors: Literal["muted", "deep", "Set2", "tab10"] = "muted",
+        theme: None | str = None,
     ) -> Self:
         """Plot DEA results.
 
@@ -24,15 +23,13 @@ class DeaPlotter:
         ----------
         model : Self@DeaEngine
             Object containing the results of a DEA analysis to be plotted.
-        theme : str {"ticks", "whitegrid", "darkgrid"}, optional, default: "ticks"
-            Name of a seaborn style. Passed through to
-            seaborn.set_theme().
-        colors : str {"muted", "deep", "Set2", "tab10"}, optional, default: "muted"
-            Name of a seaborn or matplotlib color palette. Passed
-            through to seaborn.set_theme().
+        theme : None | str, optional, default: None
+            Must be either None or a string corresponding to a
+            matplotlib.pyplot style.
 
         """
-        sns.set_theme(context="notebook", style=theme, palette=colors)
+        if theme is not None:
+            plt.style.use(style=theme)
         self.window_lengths = model.window_lengths
         self.entropies = model.entropies
         self.delta = model.fit_coefficients[0]


### PR DESCRIPTION
# Proposed changes

Using seaborn.set_theme results in good looking figures but is a bit draconian. Allowing the user to specify a matplotlib style instead makes customization easier, and the user can always call seaborn.set_theme themself if they want it.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
