### PR TITLE
✨ENH - Allow user to specify histogram binning method

### DIFF
--- a/src/pymdea/core.py
+++ b/src/pymdea/core.py
@@ -140,9 +140,28 @@ class DeaLoader:
 class DeaEngine:
     """Run diffusion entropy analysis."""
 
-    def __init__(self: Self, loader: DeaLoader) -> Self:
-        """Run diffusion entropy analysis."""
+    def __init__(
+        self: Self,
+        loader: DeaLoader,
+        hist_bins: int
+        | Literal["fd", "doane", "scott", "stone", "rice", "sturges"] = "doane",
+    ) -> Self:
+        """Run diffusion entropy analysis.
+
+        Parameters
+        ----------
+        loader : DeaLoader
+            An instance of the DeaLoader class containing data to be
+            analysed.
+        hist_bins : int | {"auto", "fd", "doane", "scott", "stone", "rice", "sturges"}
+            Number of bins, or method by which to calculate it, to use
+            for the histogram in the Shannon entropy calculation. Refer
+            to `numpy.histogram_bin_edges` for details about the
+            binning methods.
+
+        """
         self.data = loader.data
+        self.hist_bins = hist_bins
         self.progress = Progress(
             SpinnerColumn(),
             TextColumn("[progress.percentage]{task.percentage:>3.0f}%"),
@@ -204,7 +223,7 @@ class DeaEngine:
                 displacements = (
                     self.trajectory[window_ends] - self.trajectory[window_starts]
                 )
-                counts, bin_edge = np.histogram(displacements, bins="doane")
+                counts, bin_edge = np.histogram(displacements, bins=self.hist_bins)
                 counts = np.array(counts[counts != 0])
                 binsize = bin_edge[1] - bin_edge[0]
                 distribution = counts / np.sum(counts)


### PR DESCRIPTION
# Proposed changes

Different binning methods can produce very different histograms, which can impact the entropy calculation. The `doane` method is a reliable general-purpose default that behaves reasonably well in most use cases, but it's beneficial to surface this option to users to make it accessible and clear that it's a variable which can impact results.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
