### PR TITLE
✨ENH - Specify maximum window length and number of window lengths

### DIFF
--- a/src/pymdea/core.py
+++ b/src/pymdea/core.py
@@ -176,7 +176,7 @@ class DeaEngine:
             msg = (
                 "Parameter 'max_fit' must be less than "
                 f"window_stop * len(data) = {int(window_stop * len(loader.data))}, "
-                f"got: {window_stop}"
+                f"got: {max_fit}"
             )
             raise ValueError(msg)
         self.data = loader.data

--- a/src/pymdea/core.py
+++ b/src/pymdea/core.py
@@ -146,6 +146,7 @@ class DeaEngine:
         hist_bins: int
         | Literal["fd", "doane", "scott", "stone", "rice", "sturges"] = "doane",
         window_stop: float = 0.25,
+        max_fit: int = 250,
     ) -> Self:
         """Run diffusion entropy analysis.
 
@@ -163,14 +164,25 @@ class DeaEngine:
             Proportion of data length at which to cap window length.
             For example, if set to 0.25, 0.25 * len(data) will be the
             maximum window length. Must be a float in (0, 1].
+        max_fit : int
+            Maximum number of window lengths to use and fit over.
+            Window lengths will be evenly spaced in log-scale.
 
         """
         if window_stop <= 0 or window_stop > 1:
             msg = f"Parameter 'window_stop' must be in (0, 1], got: {window_stop}"
             raise ValueError(msg)
+        if max_fit > int(np.floor(window_stop * len(loader.data))):
+            msg = (
+                "Parameter 'max_fit' must be less than "
+                f"window_stop * len(data) = {int(window_stop * len(loader.data))}, "
+                f"got: {window_stop}"
+            )
+            raise ValueError(msg)
         self.data = loader.data
         self.hist_bins = hist_bins
         self.window_stop = window_stop
+        self.max_fit = max_fit
         self.progress = Progress(
             SpinnerColumn(),
             TextColumn("[progress.percentage]{task.percentage:>3.0f}%"),

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,8 +1,10 @@
 """Tests for the core methods."""
 
+import re
 from typing import Self
 
 import numpy as np
+import pytest
 
 from src.pymdea.core import DeaEngine, DeaLoader
 
@@ -31,6 +33,41 @@ class TestLoader:
 
 class TestEngine:
     """Tests for the DeaEngine."""
+
+    def test_max_fit_too_large(self: Self) -> None:
+        """Test that exception is raised if max_fit is too large."""
+        dea_loader = DeaLoader()
+        dea_loader.make_sample_data(1000)
+        too_large = 1000000
+        expect_msg = re.escape(
+            "Parameter 'max_fit' must be less than "
+            f"window_stop * len(data) = {int(0.2 * len(dea_loader.data))}, "
+            f"got: {too_large}",
+        )
+        with pytest.raises(ValueError, match=expect_msg):
+            _ = DeaEngine(dea_loader, window_stop=0.2, max_fit=too_large)
+
+    def test_window_stop_too_large(self: Self) -> None:
+        """Test that exception is raised if window_stop is too large."""
+        dea_loader = DeaLoader()
+        dea_loader.make_sample_data(1000)
+        too_large = 1.0001
+        expect_msg = re.escape(
+            f"Parameter 'window_stop' must be in (0, 1], got: {too_large}",
+        )
+        with pytest.raises(ValueError, match=expect_msg):
+            _ = DeaEngine(dea_loader, window_stop=too_large)
+
+    def test_window_stop_too_small(self: Self) -> None:
+        """Test that exception is raised if window_stop is too small."""
+        dea_loader = DeaLoader()
+        dea_loader.make_sample_data(1000)
+        too_small = 0.0
+        expect_msg = re.escape(
+            f"Parameter 'window_stop' must be in (0, 1], got: {too_small}",
+        )
+        with pytest.raises(ValueError, match=expect_msg):
+            _ = DeaEngine(dea_loader, window_stop=too_small)
 
     def test_apply_stripes(self: Self) -> None:
         """Test the _apply_stripes method."""


### PR DESCRIPTION
# Proposed changes

**Allow user to specify the maximum window length**
Previous behavior was hard-coded to use `0.25 * len(data)` as the maximum window length. In many cases this is about when the window lengths get large enough relative to the data length that the entropy calculation starts to suffer from insufficient statistics and become uninformative. However, it's better to allow a user to override the maximum, if desired.

**Allow user to specify the number of window lengths**
PR #51 introduced using a set number of even log-spaced window lengths, hard-coding the number of window lengths used to 1000. That's sufficiently many for a good linear fit, however, it's better to allow a user to override the maximum, if desired.

**Change default number of window lengths to 250**
PR #51 hard-coded the number of window lengths used to 1000. This was fewer than often had been generated previously and provided a significant performance boost at the time. However, for very long input data series 1000 still needlessly bottle-necked runtime. Using 250 is still sufficient to get good fit statistics but is faster. Now that the number of window lengths is configurable, decreasing this default is reasonable.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
