### PR TITLE
MNT - Set max_fit equal to number of window lengths and log warning if initially set larger

### DIFF
--- a/src/pymdea/core.py
+++ b/src/pymdea/core.py
@@ -172,13 +172,15 @@ class DeaEngine:
         if window_stop <= 0 or window_stop > 1:
             msg = f"Parameter 'window_stop' must be in (0, 1], got: {window_stop}"
             raise ValueError(msg)
-        if max_fit > int(np.floor(window_stop * len(loader.data))):
+        n_windows = int(np.floor(window_stop * len(loader.data)))
+        if max_fit > n_windows:
+            logger = logging.getLogger(__name__)
             msg = (
-                "Parameter 'max_fit' must be less than "
-                f"window_stop * len(data) = {int(window_stop * len(loader.data))}, "
-                f"got: {max_fit}"
+                f"Parameter max_fit={max_fit} longer than "
+                f"window_stop * len(data) = {n_windows}, "
+                f"{n_windows} will be used"
             )
-            raise ValueError(msg)
+            logger.info(msg)
         self.data = loader.data
         self.hist_bins = hist_bins
         self.window_stop = window_stop

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -34,19 +34,6 @@ class TestLoader:
 class TestEngine:
     """Tests for the DeaEngine."""
 
-    def test_max_fit_too_large(self: Self) -> None:
-        """Test that exception is raised if max_fit is too large."""
-        dea_loader = DeaLoader()
-        dea_loader.make_sample_data(1000)
-        too_large = 1000000
-        expect_msg = re.escape(
-            "Parameter 'max_fit' must be less than "
-            f"window_stop * len(data) = {int(0.2 * len(dea_loader.data))}, "
-            f"got: {too_large}",
-        )
-        with pytest.raises(ValueError, match=expect_msg):
-            _ = DeaEngine(dea_loader, window_stop=0.2, max_fit=too_large)
-
     def test_window_stop_too_large(self: Self) -> None:
         """Test that exception is raised if window_stop is too large."""
         dea_loader = DeaLoader()


### PR DESCRIPTION
# Proposed changes

If `DeaEngine.max_fit` is initially set to be greater than the number of available window lengths, set `max_fit` equal to the number of available window lengths and log a warning, instead of raising an exception and stopping.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
