### PR TITLE
🐞FIX - Pass max_fit option properly

### DIFF
--- a/src/pymdea/core.py
+++ b/src/pymdea/core.py
@@ -244,7 +244,7 @@ class DeaEngine:
             np.logspace(
                 start=0,
                 stop=np.log10(self.window_stop * len(self.trajectory)),
-                num=1000,
+                num=self.max_fit,
                 dtype=np.int32,
             ),
         )


### PR DESCRIPTION
# Proposed changes

Fix an issue where `DeaEngine.max_fit` wasn't actually being passed through to the number of window lengths calculation.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
